### PR TITLE
Add polynomial expression

### DIFF
--- a/plonkish_backend/src/backend/hyperplonk/preprocessor.rs
+++ b/plonkish_backend/src/backend/hyperplonk/preprocessor.rs
@@ -51,9 +51,7 @@ pub(super) fn compose<F: PrimeField>(
     (num_permutation_z_polys, expression)
 }
 
-pub(super) fn max_degree<F: PrimeField>(
-    circuit_info: &PlonkishCircuitInfo<F>,
-) -> usize {
+pub(super) fn max_degree<F: PrimeField>(circuit_info: &PlonkishCircuitInfo<F>) -> usize {
     iter::empty()
         .chain(circuit_info.constraints.iter().map(Expression::degree))
         .chain(circuit_info.max_degree)

--- a/plonkish_backend/src/backend/lookup/lasso.rs
+++ b/plonkish_backend/src/backend/lookup/lasso.rs
@@ -3,7 +3,8 @@ use std::{fmt::Debug, marker::PhantomData};
 use halo2_curves::ff::{Field, PrimeField};
 
 use crate::{
-    pcs::PolynomialCommitmentScheme, poly::multilinear::MultilinearPolynomial,
+    pcs::PolynomialCommitmentScheme,
+    poly::multilinear::{MultilinearPolynomial, MultilinearPolynomialTerms},
     util::expression::Expression,
 };
 
@@ -23,6 +24,7 @@ pub trait DecomposableTable<F: PrimeField>: Debug + Sync + DecomposableTableClon
 
     /// Returns multilinear extension polynomials of each subtable
     fn subtable_polys(&self) -> Vec<MultilinearPolynomial<F>>;
+    fn subtable_polys_terms(&self) -> Vec<MultilinearPolynomialTerms<F>>;
 
     fn combine_lookup_expressions(&self, expressions: Vec<Expression<F>>) -> Expression<F>;
 

--- a/plonkish_backend/src/backend/lookup/lasso/memory_checking/verifier.rs
+++ b/plonkish_backend/src/backend/lookup/lasso/memory_checking/verifier.rs
@@ -84,7 +84,7 @@ impl<F: PrimeField> Chunk<F> {
                 write_xs[i],
                 hash(&dim_x, &e_poly_xs[i], &(read_ts_poly_x + F::ONE))
             );
-            let subtable_poly_y = memory.subtable_poly_new.evaluate(y);
+            let subtable_poly_y = memory.subtable_poly.evaluate(y);
             assert_eq!(init_ys[i], hash(&id_poly_y, &subtable_poly_y, &F::ZERO));
             assert_eq!(
                 final_read_ys[i],
@@ -98,14 +98,14 @@ impl<F: PrimeField> Chunk<F> {
 #[derive(Clone, Debug)]
 pub(in crate::backend::lookup::lasso) struct Memory<F> {
     memory_index: usize,
-    subtable_poly_new: MultilinearPolynomialTerms<F>,
+    subtable_poly: MultilinearPolynomialTerms<F>,
 }
 
 impl<F> Memory<F> {
     pub fn new(memory_index: usize, subtable_poly: MultilinearPolynomialTerms<F>) -> Self {
         Self {
             memory_index,
-            subtable_poly_new: subtable_poly,
+            subtable_poly,
         }
     }
 }

--- a/plonkish_backend/src/backend/lookup/lasso/memory_checking/verifier.rs
+++ b/plonkish_backend/src/backend/lookup/lasso/memory_checking/verifier.rs
@@ -6,7 +6,7 @@ use itertools::{chain, Itertools};
 use crate::{
     pcs::Evaluation,
     piop::gkr::verify_grand_product,
-    poly::multilinear::MultilinearPolynomial,
+    poly::multilinear::{MultilinearPolynomial, MultilinearPolynomialTerms},
     util::{arithmetic::inner_product, transcript::FieldTranscriptRead},
     Error,
 };
@@ -84,7 +84,7 @@ impl<F: PrimeField> Chunk<F> {
                 write_xs[i],
                 hash(&dim_x, &e_poly_xs[i], &(read_ts_poly_x + F::ONE))
             );
-            let subtable_poly_y = memory.subtable_poly.evaluate(y);
+            let subtable_poly_y = memory.subtable_poly_new.evaluate(y);
             assert_eq!(init_ys[i], hash(&id_poly_y, &subtable_poly_y, &F::ZERO));
             assert_eq!(
                 final_read_ys[i],
@@ -99,13 +99,19 @@ impl<F: PrimeField> Chunk<F> {
 pub(in crate::backend::lookup::lasso) struct Memory<F> {
     memory_index: usize,
     subtable_poly: MultilinearPolynomial<F>,
+    subtable_poly_new: MultilinearPolynomialTerms<F>,
 }
 
 impl<F> Memory<F> {
-    pub fn new(memory_index: usize, subtable_poly: MultilinearPolynomial<F>) -> Self {
+    pub fn new(
+        memory_index: usize,
+        subtable_poly: MultilinearPolynomial<F>,
+        s: MultilinearPolynomialTerms<F>,
+    ) -> Self {
         Self {
             memory_index,
             subtable_poly,
+            subtable_poly_new: s,
         }
     }
 }

--- a/plonkish_backend/src/backend/lookup/lasso/memory_checking/verifier.rs
+++ b/plonkish_backend/src/backend/lookup/lasso/memory_checking/verifier.rs
@@ -6,7 +6,7 @@ use itertools::{chain, Itertools};
 use crate::{
     pcs::Evaluation,
     piop::gkr::verify_grand_product,
-    poly::multilinear::{MultilinearPolynomial, MultilinearPolynomialTerms},
+    poly::multilinear::MultilinearPolynomialTerms,
     util::{arithmetic::inner_product, transcript::FieldTranscriptRead},
     Error,
 };
@@ -98,20 +98,14 @@ impl<F: PrimeField> Chunk<F> {
 #[derive(Clone, Debug)]
 pub(in crate::backend::lookup::lasso) struct Memory<F> {
     memory_index: usize,
-    subtable_poly: MultilinearPolynomial<F>,
     subtable_poly_new: MultilinearPolynomialTerms<F>,
 }
 
 impl<F> Memory<F> {
-    pub fn new(
-        memory_index: usize,
-        subtable_poly: MultilinearPolynomial<F>,
-        s: MultilinearPolynomialTerms<F>,
-    ) -> Self {
+    pub fn new(memory_index: usize, subtable_poly: MultilinearPolynomialTerms<F>) -> Self {
         Self {
             memory_index,
-            subtable_poly,
-            subtable_poly_new: s,
+            subtable_poly_new: subtable_poly,
         }
     }
 }

--- a/plonkish_backend/src/backend/lookup/lasso/prover/surge.rs
+++ b/plonkish_backend/src/backend/lookup/lasso/prover/surge.rs
@@ -66,7 +66,10 @@ impl<
             .map(|i| {
                 let mut index_bits = fe_to_bits_le(nz_poly[i]);
                 index_bits.truncate(table.chunk_bits().iter().sum());
-                assert_eq!(usize_from_bits_le(&fe_to_bits_le(nz_poly[i])), usize_from_bits_le(&index_bits));
+                assert_eq!(
+                    usize_from_bits_le(&fe_to_bits_le(nz_poly[i])),
+                    usize_from_bits_le(&index_bits)
+                );
 
                 let mut chunked_index = repeat(0).take(num_chunks).collect_vec();
                 let chunked_index_bits = table.subtable_indices(index_bits);

--- a/plonkish_backend/src/backend/lookup/lasso/test/and.rs
+++ b/plonkish_backend/src/backend/lookup/lasso/test/and.rs
@@ -29,7 +29,6 @@ impl<F: PrimeField> DecomposableTable<F> for AndTable<F> {
 
     fn subtable_polys(&self) -> Vec<MultilinearPolynomial<F>> {
         let memory_size = 1 << 16;
-        println!("{}", self.num_memories());
         let mut evals = vec![];
         (0..memory_size).for_each(|i| {
             let (lhs, rhs) = split_bits(i, 8);
@@ -40,12 +39,12 @@ impl<F: PrimeField> DecomposableTable<F> for AndTable<F> {
     }
 
     fn subtable_polys_terms(&self) -> Vec<MultilinearPolynomialTerms<F>> {
-        let init = Prod(vec![Var(0), Var(16)]);
+        let init = Prod(vec![Var(0), Var(8)]);
         let mut terms = vec![init];
-        (1..16).for_each(|i| {
-            let coeff = Pow(Box::new(Const(F::from(2))), i as u32);
+        (1..8).for_each(|i| {
+            let coeff = Const(F::from(1 << i));
             let x = Var(i);
-            let y = Var(i + 16);
+            let y = Var(i + 8);
             let term = Prod(vec![coeff, x, y]);
             terms.push(term);
         });

--- a/plonkish_backend/src/backend/lookup/lasso/test/and.rs
+++ b/plonkish_backend/src/backend/lookup/lasso/test/and.rs
@@ -40,19 +40,16 @@ impl<F: PrimeField> DecomposableTable<F> for AndTable<F> {
     }
 
     fn subtable_polys_terms(&self) -> Vec<MultilinearPolynomialTerms<F>> {
-        let init = Prod(vec![Var(0), Var(self.num_memories())]);
+        let init = Prod(vec![Var(0), Var(16)]);
         let mut terms = vec![init];
         (1..16).for_each(|i| {
             let coeff = Pow(Box::new(Const(F::from(2))), i as u32);
             let x = Var(i);
-            let y = Var(i + self.num_memories());
+            let y = Var(i + 16);
             let term = Prod(vec![coeff, x, y]);
             terms.push(term);
         });
-        vec![MultilinearPolynomialTerms::new(
-            16,
-            Sum(terms),
-        )]
+        vec![MultilinearPolynomialTerms::new(16, Sum(terms))]
     }
 
     fn chunk_bits(&self) -> Vec<usize> {

--- a/plonkish_backend/src/backend/lookup/lasso/test/range.rs
+++ b/plonkish_backend/src/backend/lookup/lasso/test/range.rs
@@ -90,10 +90,7 @@ impl<F: PrimeField, const NUM_BITS: usize, const LIMB_BITS: usize> DecomposableT
             let term = Prod(vec![coeff, x]);
             limb_terms.push(term);
         });
-        let limb_subtable_poly = MultilinearPolynomialTerms::new(
-            LIMB_BITS,
-            Sum(limb_terms),
-        );
+        let limb_subtable_poly = MultilinearPolynomialTerms::new(LIMB_BITS, Sum(limb_terms));
         if NUM_BITS % LIMB_BITS == 0 {
             vec![limb_subtable_poly]
         } else {
@@ -106,9 +103,11 @@ impl<F: PrimeField, const NUM_BITS: usize, const LIMB_BITS: usize> DecomposableT
                 let term = Prod(vec![coeff, x]);
                 rem_terms.push(term);
             });
-            vec![limb_subtable_poly, MultilinearPolynomialTerms::new(remainder, Sum(rem_terms))]
+            vec![
+                limb_subtable_poly,
+                MultilinearPolynomialTerms::new(remainder, Sum(rem_terms)),
+            ]
         }
-        
     }
 
     fn memory_to_chunk_index(&self, memory_index: usize) -> usize {

--- a/plonkish_backend/src/backend/lookup/lasso/verifier/mod.rs
+++ b/plonkish_backend/src/backend/lookup/lasso/verifier/mod.rs
@@ -92,16 +92,14 @@ impl<
     fn chunks(table: &Box<dyn DecomposableTable<F>>) -> Vec<Chunk<F>> {
         let num_memories = table.num_memories();
         let chunk_bits = table.chunk_bits();
-        let subtable_polys = table.subtable_polys();
         let s_new = table.subtable_polys_terms();
         // key: chunk index, value: chunk
         let mut chunk_map: HashMap<usize, Chunk<F>> = HashMap::new();
         (0..num_memories).for_each(|memory_index| {
             let chunk_index = table.memory_to_chunk_index(memory_index);
             let chunk_bits = chunk_bits[chunk_index];
-            let subtable_poly = &subtable_polys[table.memory_to_subtable_index(memory_index)];
             let s = &s_new[table.memory_to_subtable_index(memory_index)];
-            let memory = Memory::new(memory_index, subtable_poly.clone(), s.clone());
+            let memory = Memory::new(memory_index, s.clone());
             if chunk_map.get(&chunk_index).is_some() {
                 chunk_map.entry(chunk_index).and_modify(|chunk| {
                     chunk.add_memory(memory);

--- a/plonkish_backend/src/backend/lookup/lasso/verifier/mod.rs
+++ b/plonkish_backend/src/backend/lookup/lasso/verifier/mod.rs
@@ -92,14 +92,14 @@ impl<
     fn chunks(table: &Box<dyn DecomposableTable<F>>) -> Vec<Chunk<F>> {
         let num_memories = table.num_memories();
         let chunk_bits = table.chunk_bits();
-        let s_new = table.subtable_polys_terms();
+        let subtable_polys = table.subtable_polys_terms();
         // key: chunk index, value: chunk
         let mut chunk_map: HashMap<usize, Chunk<F>> = HashMap::new();
         (0..num_memories).for_each(|memory_index| {
             let chunk_index = table.memory_to_chunk_index(memory_index);
             let chunk_bits = chunk_bits[chunk_index];
-            let s = &s_new[table.memory_to_subtable_index(memory_index)];
-            let memory = Memory::new(memory_index, s.clone());
+            let subtable_poly = &subtable_polys[table.memory_to_subtable_index(memory_index)];
+            let memory = Memory::new(memory_index, subtable_poly.clone());
             if chunk_map.get(&chunk_index).is_some() {
                 chunk_map.entry(chunk_index).and_modify(|chunk| {
                     chunk.add_memory(memory);

--- a/plonkish_backend/src/backend/lookup/lasso/verifier/mod.rs
+++ b/plonkish_backend/src/backend/lookup/lasso/verifier/mod.rs
@@ -93,13 +93,15 @@ impl<
         let num_memories = table.num_memories();
         let chunk_bits = table.chunk_bits();
         let subtable_polys = table.subtable_polys();
+        let s_new = table.subtable_polys_terms();
         // key: chunk index, value: chunk
         let mut chunk_map: HashMap<usize, Chunk<F>> = HashMap::new();
         (0..num_memories).for_each(|memory_index| {
             let chunk_index = table.memory_to_chunk_index(memory_index);
             let chunk_bits = chunk_bits[chunk_index];
             let subtable_poly = &subtable_polys[table.memory_to_subtable_index(memory_index)];
-            let memory = Memory::new(memory_index, subtable_poly.clone());
+            let s = &s_new[table.memory_to_subtable_index(memory_index)];
+            let memory = Memory::new(memory_index, subtable_poly.clone(), s.clone());
             if chunk_map.get(&chunk_index).is_some() {
                 chunk_map.entry(chunk_index).and_modify(|chunk| {
                     chunk.add_memory(memory);

--- a/plonkish_backend/src/poly/multilinear.rs
+++ b/plonkish_backend/src/poly/multilinear.rs
@@ -56,21 +56,15 @@ impl<F: Field> PolyExpr<F> {
         match self {
             PolyExpr::Const(c) => c.clone(),
             PolyExpr::Var(i) => x[*i],
-            PolyExpr::Sum(v) => {
-                v.par_iter().map(|t| {
-                    t.evaluate(x)
-                }).reduce(|| F::ZERO, |acc, f| acc + f)
-            }
-            PolyExpr::Prod(v) => {
-                v.par_iter().map(|t| {
-                    t.evaluate(x)
-                }).reduce(|| F::ONE, |acc, f| acc * f)
-            }
-            PolyExpr::Pow(inner, e) => {
-                let res = inner.evaluate(x);
-                let exp = [*e as u64];
-                res.pow(exp)
-            }
+            PolyExpr::Sum(v) => v
+                .par_iter()
+                .map(|t| t.evaluate(x))
+                .reduce(|| F::ZERO, |acc, f| acc + f),
+            PolyExpr::Prod(v) => v
+                .par_iter()
+                .map(|t| t.evaluate(x))
+                .reduce(|| F::ONE, |acc, f| acc * f),
+            PolyExpr::Pow(inner, e) => inner.evaluate(x).pow([*e as u64]),
         }
     }
 }


### PR DESCRIPTION
## Description
To optimize the performance of verifier, add polynomial expression and new format of multilinear polynomial (it can be used for general multivariate polynomial as well)
```rust
pub enum PolyExpr<F> {
    Const(F),
    Var(usize),
    Sum(Vec<PolyExpr<F>>),
    Prod(Vec<PolyExpr<F>>),
    Pow(Box<PolyExpr<F>>, u32),
}
```
### Remaining works
- Replace `subtable_poly: MultilinearPolynomial` with `subtable_poly: MultilinearPolynomialTerms`
#### Related issue
#10